### PR TITLE
Make "constants" like `AA-AA`, `A`, `A1`, etc are recognized

### DIFF
--- a/WhizzML.sublime-syntax
+++ b/WhizzML.sublime-syntax
@@ -643,8 +643,10 @@ contexts:
       captures:
         2: invalid.illegal.escape.string.whizzml
   symbol:
-    - match: '\b[A-Z_]{2,}\b'
-      scope: constant.other.whizzml.whizzml
+    - match: '\b[A-Z]\b'
+      scope: constant.other.single.whizzml
+    - match: '\b[A-Z0-9_\-]{2,}\b'
+      scope: constant.other.multiple.whizzml
     - match: '(?<![a-zA-Z+!\-_?0-9*])\*[a-z\-]{2,}\*(?![a-zA-Z+!\-_?0-9*])'
       scope: source.symbol.global.whizzml
     - match: '(?=[a-zA-Z+!\-_?0-9*=])'

--- a/syntax_test.whizzml
+++ b/syntax_test.whizzml
@@ -82,3 +82,15 @@
   (when (negative? (get-x))
     (raise {"code" -1 "message" "Error: negative x"}))
   (do-something (get-x)))
+
+(define A "foo")
+;       ^ constant.other.single.whizzml
+
+(define AAAA "foo")
+;       ^ constant.other.multiple.whizzml
+
+(define AA-AA "foo")
+;       ^ constant.other.multiple.whizzml
+
+(define 1 "aaaa")
+;       ^invalid.illegal.symbol.whizzml


### PR DESCRIPTION
As always, a tag will be required.